### PR TITLE
deprecate callooktools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # callooktools
 
+# **WARNING:** This library is now deprecated. Use [callsignlookuptools](https://pypi.org/project/callsignlookuptools/) instead.
+
 [Callook.info](https://callook.info) API interface in Python
 
 [![PyPI](https://img.shields.io/pypi/v/callooktools)](https://pypi.org/project/callooktools/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/callooktools) ![PyPI - License](https://img.shields.io/pypi/l/callooktools) [![Documentation Status](https://readthedocs.org/projects/callooktools/badge/?version=latest)](https://callooktools.readthedocs.io/en/latest/?badge=latest)

--- a/callooktools/__info__.py
+++ b/callooktools/__info__.py
@@ -3,7 +3,7 @@
 
 
 __project__ = "callooktools"
-__summary__ = "callook.info API interface in Python"
+__summary__ = "DEPRECATED - callook.info API interface in Python"
 __webpage__ = "https://callooktools.miaow.io"
 
 __version__ = "1.0.0"

--- a/callooktools/__init__.py
+++ b/callooktools/__init__.py
@@ -8,10 +8,13 @@ Released under the terms of the BSD 3-Clause license.
 """
 
 from importlib.util import find_spec
+from warnings import warn
 
 from .__info__ import __version__  # noqa: F401
 
 from .callooktools import CallookError, CallookCallsignData, CallookAbc  # noqa: F401
+
+warn("This library is now deprecated. Use callsignlookuptools instead.", DeprecationWarning, stacklevel=2)
 
 if find_spec("requests"):
     from .callooksync import CallookSync  # noqa: F401

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,8 @@
 API Reference
 =============
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 ``callooktools`` allows for both synchronous and asynchronous usage via two main classes, :class:`callooktools.CallookSync` and :class:`callooktools.CallookAsync`.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,6 +2,8 @@
 CLI Usage
 =========
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 .. NOTE:: To use the CLI, install with the extra ``cli`` (e.g. ``pip install callooktools[cli]``) or otherwise install the library ``rich``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,8 @@
 CallookTools
 ============
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 A Callook.info API interface in Python with sync and async support.
 
 .. highlight:: none

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -2,6 +2,8 @@
 Types
 =====
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 .. module:: callooktools.callooktools

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Fixes #3 

* adds a warning to all documentation, README, and pypi description
* adds `DeprecationWarning` on import:

```py
>>> import callooktools
<stdin>:1: DeprecationWarning: This library is now deprecated. Use callsignlookuptools instead.
```

This PR should not be merged until miaowware/callsignlookuptools 1.0.0 release.